### PR TITLE
fix(errors): do not wrap errors unnecessarily

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@types/uuid": "7.0.2",
     "@typescript-eslint/eslint-plugin": "2.28.0",
     "@typescript-eslint/parser": "2.28.0",
+    "apollo-errors": "1.9.0",
     "babel-eslint": "10.1.0",
     "body-parser": "1.19.0",
     "dataloader": "2.0.0",

--- a/src/delegate/results/handleNull.ts
+++ b/src/delegate/results/handleNull.ts
@@ -1,10 +1,6 @@
 import { FieldNode, GraphQLError } from 'graphql';
 
-import {
-  getErrorsByPathSegment,
-  combineErrors,
-  relocatedError,
-} from '../../stitch/errors';
+import { getErrorsByPathSegment, combineErrors } from '../../stitch/errors';
 
 export function handleNull(
   fieldNodes: ReadonlyArray<FieldNode>,
@@ -13,7 +9,7 @@ export function handleNull(
 ) {
   if (errors.length) {
     if (errors.some((error) => !error.path || error.path.length < 2)) {
-      return relocatedError(combineErrors(errors), fieldNodes, path);
+      return combineErrors(errors);
     } else if (errors.some((error) => typeof error.path[1] === 'string')) {
       const childErrors = getErrorsByPathSegment(errors);
 

--- a/src/delegate/results/handleObject.ts
+++ b/src/delegate/results/handleObject.ts
@@ -16,7 +16,7 @@ import {
   isSubschemaConfig,
   GraphQLExecutionContext,
 } from '../../Interfaces';
-import { setErrors, relocatedError } from '../../stitch/errors';
+import { setErrors, slicedError } from '../../stitch/errors';
 import { setObjectSubschema } from '../../stitch/subSchema';
 import resolveFromParentTypename from '../../stitch/resolveFromParentTypename';
 import { mergeFields } from '../../stitch/mergeFields';
@@ -32,13 +32,7 @@ export function handleObject(
 ) {
   setErrors(
     object,
-    errors.map((error) =>
-      relocatedError(
-        error,
-        error.nodes,
-        error.path != null ? error.path.slice(1) : undefined,
-      ),
-    ),
+    errors.map((error) => slicedError(error)),
   );
 
   setObjectSubschema(object, subschema);

--- a/src/stitch/proxiedResult.ts
+++ b/src/stitch/proxiedResult.ts
@@ -42,7 +42,6 @@ export function unwrapResult(
       errors.map((error) =>
         relocatedError(
           error,
-          error.nodes,
           error.path != null ? error.path.slice(1) : undefined,
         ),
       ),
@@ -79,11 +78,7 @@ export function dehoistResult(
       const expandedPathSegment: Array<
         string | number
       > = (pathSegment as string).split(delimeter);
-      return relocatedError(
-        error,
-        error.nodes,
-        expandedPathSegment.concat(path),
-      );
+      return relocatedError(error, expandedPathSegment.concat(path));
     }
 
     return error;

--- a/src/test/alternateMergeSchemas.test.ts
+++ b/src/test/alternateMergeSchemas.test.ts
@@ -767,12 +767,13 @@ type Query {
           ],
           message: 'Property.error error',
           path: ['propertyById', 'new_error'],
-          extensions: {
-            code: 'SOME_CUSTOM_CODE',
-          },
         },
       ],
     };
+
+    if (graphqlVersion() >= 14) {
+      expectedResult.errors[0].extensions = { code: 'SOME_CUSTOM_CODE' };
+    }
 
     expect(result).toEqual(expectedResult);
   });
@@ -932,12 +933,13 @@ describe('WrapType transform', () => {
           ],
           message: 'Property.error error',
           path: ['namespace', 'propertyById', 'error'],
-          extensions: {
-            code: 'SOME_CUSTOM_CODE',
-          },
         },
       ],
     };
+
+    if (graphqlVersion() >= 14) {
+      expectedResult.errors[0].extensions = { code: 'SOME_CUSTOM_CODE' };
+    }
 
     expect(result).toEqual(expectedResult);
   });
@@ -1006,12 +1008,13 @@ describe('schema transformation with extraction of nested fields', () => {
           ],
           message: 'Property.error error',
           path: ['propertyById', 'renamedError'],
-          extensions: {
-            code: 'SOME_CUSTOM_CODE',
-          },
         },
       ],
     };
+
+    if (graphqlVersion() >= 14) {
+      expectedResult.errors[0].extensions = { code: 'SOME_CUSTOM_CODE' };
+    }
 
     expect(result).toEqual(expectedResult);
   });
@@ -1143,12 +1146,13 @@ describe('schema transformation with wrapping of object fields', () => {
           ],
           message: 'Property.error error',
           path: ['propertyById', 'test1', 'innerWrap', 'two'],
-          extensions: {
-            code: 'SOME_CUSTOM_CODE',
-          },
         },
       ],
     };
+
+    if (graphqlVersion() >= 14) {
+      expectedResult.errors[0].extensions = { code: 'SOME_CUSTOM_CODE' };
+    }
 
     expect(result).toEqual(expectedResult);
   });
@@ -1214,12 +1218,13 @@ describe('schema transformation with wrapping of object fields', () => {
             ],
             message: 'Property.error error',
             path: ['propertyById', 'test1', 'two'],
-            extensions: {
-              code: 'SOME_CUSTOM_CODE',
-            },
           },
         ],
       };
+
+      if (graphqlVersion() >= 14) {
+        expectedResult.errors[0].extensions = { code: 'SOME_CUSTOM_CODE' };
+      }
 
       expect(result).toEqual(expectedResult);
     });
@@ -1292,12 +1297,13 @@ describe('schema transformation with wrapping of object fields', () => {
             ],
             message: 'Property.error error',
             path: ['propertyById', 'test1', 'innerWrap', 'two'],
-            extensions: {
-              code: 'SOME_CUSTOM_CODE',
-            },
           },
         ],
       };
+
+      if (graphqlVersion() >= 14) {
+        expectedResult.errors[0].extensions = { code: 'SOME_CUSTOM_CODE' };
+      }
 
       expect(result).toEqual(expectedResult);
     });
@@ -1359,12 +1365,13 @@ describe('schema transformation with renaming of object fields', () => {
           ],
           message: 'Property.error error',
           path: ['propertyById', 'new_error'],
-          extensions: {
-            code: 'SOME_CUSTOM_CODE',
-          },
         },
       ],
     };
+
+    if (graphqlVersion() >= 14) {
+      expectedResult.errors[0].extensions = { code: 'SOME_CUSTOM_CODE' };
+    }
 
     expect(result).toEqual(expectedResult);
   });

--- a/src/test/alternateMergeSchemas.test.ts
+++ b/src/test/alternateMergeSchemas.test.ts
@@ -767,20 +767,14 @@ type Query {
           ],
           message: 'Property.error error',
           path: ['propertyById', 'new_error'],
+          extensions: {
+            code: 'SOME_CUSTOM_CODE',
+          },
         },
       ],
     };
 
-    if (graphqlVersion() >= 14) {
-      expectedResult.errors[0].extensions = {
-        code: 'SOME_CUSTOM_CODE',
-      };
-    }
-
     expect(result).toEqual(expectedResult);
-    expect(result.errors[0].extensions).toEqual({
-      code: 'SOME_CUSTOM_CODE',
-    });
   });
 });
 
@@ -938,20 +932,14 @@ describe('WrapType transform', () => {
           ],
           message: 'Property.error error',
           path: ['namespace', 'propertyById', 'error'],
+          extensions: {
+            code: 'SOME_CUSTOM_CODE',
+          },
         },
       ],
     };
 
-    if (graphqlVersion() >= 14) {
-      expectedResult.errors[0].extensions = {
-        code: 'SOME_CUSTOM_CODE',
-      };
-    }
-
     expect(result).toEqual(expectedResult);
-    expect(result.errors[0].extensions).toEqual({
-      code: 'SOME_CUSTOM_CODE',
-    });
   });
 });
 
@@ -1018,20 +1006,14 @@ describe('schema transformation with extraction of nested fields', () => {
           ],
           message: 'Property.error error',
           path: ['propertyById', 'renamedError'],
+          extensions: {
+            code: 'SOME_CUSTOM_CODE',
+          },
         },
       ],
     };
 
-    if (graphqlVersion() >= 14) {
-      expectedResult.errors[0].extensions = {
-        code: 'SOME_CUSTOM_CODE',
-      };
-    }
-
     expect(result).toEqual(expectedResult);
-    expect(result.errors[0].extensions).toEqual({
-      code: 'SOME_CUSTOM_CODE',
-    });
   });
 
   test('should work via HoistField transform', async () => {
@@ -1161,20 +1143,14 @@ describe('schema transformation with wrapping of object fields', () => {
           ],
           message: 'Property.error error',
           path: ['propertyById', 'test1', 'innerWrap', 'two'],
+          extensions: {
+            code: 'SOME_CUSTOM_CODE',
+          },
         },
       ],
     };
 
-    if (graphqlVersion() >= 14) {
-      expectedResult.errors[0].extensions = {
-        code: 'SOME_CUSTOM_CODE',
-      };
-    }
-
     expect(result).toEqual(expectedResult);
-    expect(result.errors[0].extensions).toEqual({
-      code: 'SOME_CUSTOM_CODE',
-    });
   });
 
   describe('WrapFields transform', () => {
@@ -1238,20 +1214,14 @@ describe('schema transformation with wrapping of object fields', () => {
             ],
             message: 'Property.error error',
             path: ['propertyById', 'test1', 'two'],
+            extensions: {
+              code: 'SOME_CUSTOM_CODE',
+            },
           },
         ],
       };
 
-      if (graphqlVersion() >= 14) {
-        expectedResult.errors[0].extensions = {
-          code: 'SOME_CUSTOM_CODE',
-        };
-      }
-
       expect(result).toEqual(expectedResult);
-      expect(result.errors[0].extensions).toEqual({
-        code: 'SOME_CUSTOM_CODE',
-      });
     });
 
     test('should work, even with multiple fields', async () => {
@@ -1322,20 +1292,14 @@ describe('schema transformation with wrapping of object fields', () => {
             ],
             message: 'Property.error error',
             path: ['propertyById', 'test1', 'innerWrap', 'two'],
+            extensions: {
+              code: 'SOME_CUSTOM_CODE',
+            },
           },
         ],
       };
 
-      if (graphqlVersion() >= 14) {
-        expectedResult.errors[0].extensions = {
-          code: 'SOME_CUSTOM_CODE',
-        };
-      }
-
       expect(result).toEqual(expectedResult);
-      expect(result.errors[0].extensions).toEqual({
-        code: 'SOME_CUSTOM_CODE',
-      });
     });
   });
 });
@@ -1395,27 +1359,14 @@ describe('schema transformation with renaming of object fields', () => {
           ],
           message: 'Property.error error',
           path: ['propertyById', 'new_error'],
+          extensions: {
+            code: 'SOME_CUSTOM_CODE',
+          },
         },
       ],
     };
 
-    if (graphqlVersion() >= 14) {
-      expectedResult.errors[0].extensions = {
-        code: 'SOME_CUSTOM_CODE',
-      };
-    }
-
-    expect(result.data).toEqual(expectedResult.data);
-    expect(result.errors).toHaveLength(1);
-    expect(result.errors[0].locations).toEqual(
-      expectedResult.errors[0].locations,
-    );
-    expect(result.errors[0].message).toEqual(expectedResult.errors[0].message);
-    expect(result.errors[0].path).toEqual(expectedResult.errors[0].path);
-    // expect(result).toEqual(expectedResult);
-    expect(result.errors[0].extensions).toEqual({
-      code: 'SOME_CUSTOM_CODE',
-    });
+    expect(result).toEqual(expectedResult);
   });
 });
 

--- a/src/test/errors.test.ts
+++ b/src/test/errors.test.ts
@@ -19,17 +19,7 @@ describe('Errors', () => {
       const originalError = new GraphQLError('test', null, null, null, [
         'test',
       ]);
-      const newError = relocatedError(originalError, null, ['test', 1]);
-      const expectedError = new GraphQLError('test', null, null, null, [
-        'test',
-        1,
-      ]);
-      expect(newError).toEqual(expectedError);
-    });
-
-    test('should also locate a non GraphQLError', () => {
-      const originalError = new Error('test');
-      const newError = relocatedError(originalError, null, ['test', 1]);
+      const newError = relocatedError(originalError, ['test', 1]);
       const expectedError = new GraphQLError('test', null, null, null, [
         'test',
         1,
@@ -142,28 +132,11 @@ describe('passes along errors for missing fields on list', () => {
     const mergedSchema = mergeSchemas({
       schemas: [schema],
     });
-    const result = await graphql(
-      mergedSchema,
-      '{ getOuter { innerList { mandatoryField } } }',
-    );
-    expect(result).toEqual({
-      data: {
-        getOuter: null,
-      },
-      errors: [
-        {
-          locations: [
-            {
-              column: 26,
-              line: 1,
-            },
-          ],
-          message:
-            'Cannot return null for non-nullable field Inner.mandatoryField.',
-          path: ['getOuter', 'innerList', 1, 'mandatoryField'],
-        },
-      ],
-    });
+
+    const query = '{ getOuter { innerList { mandatoryField } } }';
+    const originalResult = await graphql(schema, query);
+    const mergedResult = await graphql(mergedSchema, query);
+    expect(mergedResult).toEqual(originalResult);
   });
 
   test('even if nullable', async () => {
@@ -193,30 +166,11 @@ describe('passes along errors for missing fields on list', () => {
     const mergedSchema = mergeSchemas({
       schemas: [schema],
     });
-    const result = await graphql(
-      mergedSchema,
-      '{ getOuter { innerList { mandatoryField } } }',
-    );
-    expect(result).toEqual({
-      data: {
-        getOuter: {
-          innerList: [{ mandatoryField: 'test' }, null],
-        },
-      },
-      errors: [
-        {
-          locations: [
-            {
-              column: 26,
-              line: 1,
-            },
-          ],
-          message:
-            'Cannot return null for non-nullable field Inner.mandatoryField.',
-          path: ['getOuter', 'innerList', 1, 'mandatoryField'],
-        },
-      ],
-    });
+
+    const query = '{ getOuter { innerList { mandatoryField } } }';
+    const originalResult = await graphql(schema, query);
+    const mergedResult = await graphql(mergedSchema, query);
+    expect(mergedResult).toEqual(originalResult);
   });
 });
 
@@ -248,27 +202,11 @@ describe('passes along errors when list field errors', () => {
     const mergedSchema = mergeSchemas({
       schemas: [schema],
     });
-    const result = await graphql(
-      mergedSchema,
-      '{ getOuter { innerList { mandatoryField } } }',
-    );
-    expect(result).toEqual({
-      data: {
-        getOuter: null,
-      },
-      errors: [
-        {
-          locations: [
-            {
-              column: 14,
-              line: 1,
-            },
-          ],
-          message: 'test',
-          path: ['getOuter', 'innerList', 1],
-        },
-      ],
-    });
+
+    const query = '{ getOuter { innerList { mandatoryField } } }';
+    const originalResult = await graphql(schema, query);
+    const mergedResult = await graphql(mergedSchema, query);
+    expect(mergedResult).toEqual(originalResult);
   });
 
   test('even if nullable', async () => {
@@ -298,28 +236,10 @@ describe('passes along errors when list field errors', () => {
     const mergedSchema = mergeSchemas({
       schemas: [schema],
     });
-    const result = await graphql(
-      mergedSchema,
-      '{ getOuter { innerList { mandatoryField } } }',
-    );
-    expect(result).toEqual({
-      data: {
-        getOuter: {
-          innerList: [{ mandatoryField: 'test' }, null],
-        },
-      },
-      errors: [
-        {
-          locations: [
-            {
-              column: 14,
-              line: 1,
-            },
-          ],
-          message: 'test',
-          path: ['getOuter', 'innerList', 1],
-        },
-      ],
-    });
+
+    const query = '{ getOuter { innerList { mandatoryField } } }';
+    const originalResult = await graphql(schema, query);
+    const mergedResult = await graphql(mergedSchema, query);
+    expect(mergedResult).toEqual(originalResult);
   });
 });

--- a/src/test/fixtures/schemas.ts
+++ b/src/test/fixtures/schemas.ts
@@ -22,6 +22,16 @@ import {
 import { makeExecutableSchema } from '../../generate/index';
 import { graphqlVersion } from '../../utils/index';
 
+export class CustomError extends Error {
+  public extensions: Record<string, any>;
+  constructor(message: string, extensions: Record<string, any>) {
+    super(message);
+    this.name = 'CustomError';
+    Object.setPrototypeOf(this, new.target.prototype);
+    this.extensions = extensions;
+  }
+}
+
 export type Location = {
   name: string;
   coordinates: string;
@@ -405,10 +415,9 @@ const propertyResolvers: IResolvers = {
 
   Property: {
     error() {
-      const error = new Error('Property.error error');
-      (error as any).extensions = {
+      const error = new CustomError('Property.error error', {
         code: 'SOME_CUSTOM_CODE',
-      };
+      });
       throw error;
     },
   },

--- a/src/test/fixtures/schemas.ts
+++ b/src/test/fixtures/schemas.ts
@@ -9,6 +9,7 @@ import {
   GraphQLScalarType,
   ValueNode,
   GraphQLResolveInfo,
+  GraphQLError,
 } from 'graphql';
 import { forAwaitEach } from 'iterall';
 
@@ -22,13 +23,17 @@ import {
 import { makeExecutableSchema } from '../../generate/index';
 import { graphqlVersion } from '../../utils/index';
 
-export class CustomError extends Error {
-  public extensions: Record<string, any>;
+export class CustomError extends GraphQLError {
   constructor(message: string, extensions: Record<string, any>) {
-    super(message);
-    this.name = 'CustomError';
-    Object.setPrototypeOf(this, new.target.prototype);
-    this.extensions = extensions;
+    super(
+      message,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      extensions,
+    );
   }
 }
 

--- a/src/test/fixtures/schemas.ts
+++ b/src/test/fixtures/schemas.ts
@@ -420,10 +420,9 @@ const propertyResolvers: IResolvers = {
 
   Property: {
     error() {
-      const error = new CustomError('Property.error error', {
+      throw new CustomError('Property.error error', {
         code: 'SOME_CUSTOM_CODE',
       });
-      throw error;
     },
   },
 };

--- a/src/test/mergeSchemas.test.ts
+++ b/src/test/mergeSchemas.test.ts
@@ -11,7 +11,6 @@ import {
   defaultFieldResolver,
   findDeprecatedUsages,
   printSchema,
-  GraphQLError,
 } from 'graphql';
 
 import { delegateToSchema } from '../delegate/index';

--- a/src/test/mergeSchemas.test.ts
+++ b/src/test/mergeSchemas.test.ts
@@ -2389,10 +2389,16 @@ fragment BookingFragment on Booking {
           {
             message: 'Property.error error',
             path: ['propertyById', 'error'],
+            extensions: {
+              code: 'SOME_CUSTOM_CODE',
+            },
           },
           {
             message: 'Property.error error',
             path: ['propertyById', 'errorAlias'],
+            extensions: {
+              code: 'SOME_CUSTOM_CODE',
+            },
           },
           {
             message: 'Booking.error error',
@@ -2420,22 +2426,7 @@ fragment BookingFragment on Booking {
           },
         ];
 
-        if (graphqlVersion() >= 14) {
-          expectedErrors[0].extensions = {
-            code: 'SOME_CUSTOM_CODE',
-          };
-          expectedErrors[1].extensions = {
-            code: 'SOME_CUSTOM_CODE',
-          };
-        }
-
         expect(errorsWithoutLocations).toEqual(expectedErrors);
-        expect(result.errors[0].extensions).toEqual({
-          code: 'SOME_CUSTOM_CODE',
-        });
-        expect(result.errors[1].extensions).toEqual({
-          code: 'SOME_CUSTOM_CODE',
-        });
       });
 
       test(

--- a/src/test/mergeSchemas.test.ts
+++ b/src/test/mergeSchemas.test.ts
@@ -11,6 +11,7 @@ import {
   defaultFieldResolver,
   findDeprecatedUsages,
   printSchema,
+  GraphQLError,
 } from 'graphql';
 
 import { delegateToSchema } from '../delegate/index';
@@ -39,6 +40,7 @@ import {
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const removeLocations = ({ locations, ...rest }: any): any => ({ ...rest });
+const errorToObject = (error: GraphQLError): GraphQLError => ({ ...error });
 
 const testCombinations = [
   {
@@ -2389,16 +2391,10 @@ fragment BookingFragment on Booking {
           {
             message: 'Property.error error',
             path: ['propertyById', 'error'],
-            extensions: {
-              code: 'SOME_CUSTOM_CODE',
-            },
           },
           {
             message: 'Property.error error',
             path: ['propertyById', 'errorAlias'],
-            extensions: {
-              code: 'SOME_CUSTOM_CODE',
-            },
           },
           {
             message: 'Booking.error error',
@@ -2425,6 +2421,11 @@ fragment BookingFragment on Booking {
             path: ['propertyById', 'bookings', 2, 'bookingErrorAlias'],
           },
         ];
+
+        if (graphqlVersion() >= 14) {
+          expectedErrors[0].extensions = { code: 'SOME_CUSTOM_CODE' };
+          expectedErrors[1].extensions = { code: 'SOME_CUSTOM_CODE' };
+        }
 
         expect(errorsWithoutLocations).toEqual(expectedErrors);
       });

--- a/src/test/mergeSchemas.test.ts
+++ b/src/test/mergeSchemas.test.ts
@@ -40,7 +40,6 @@ import {
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const removeLocations = ({ locations, ...rest }: any): any => ({ ...rest });
-const errorToObject = (error: GraphQLError): GraphQLError => ({ ...error });
 
 const testCombinations = [
   {

--- a/src/wrap/transforms/TransformQuery.ts
+++ b/src/wrap/transforms/TransformQuery.ts
@@ -7,6 +7,7 @@ import {
 } from 'graphql';
 
 import { Transform, Request, ExecutionResult } from '../../Interfaces';
+import { relocatedError } from '../../stitch/errors';
 
 export type QueryTransformer = (
   selectionSet: SelectionSetNode,
@@ -134,15 +135,7 @@ export default class TransformQuery implements Transform {
             .concat(this.errorPathTransformer(path.slice(index)))
         : path;
 
-      return new GraphQLError(
-        error.message,
-        error.nodes,
-        error.source,
-        error.positions,
-        newPath,
-        error.originalError,
-        error.extensions,
-      );
+      return relocatedError(error, newPath);
     });
   }
 }


### PR DESCRIPTION
 = combineErrors now returns the originalError if one is present.
 = relocating an error is not necessary prior to throwing, and may cause the original error to be lost.
 = The CombinedError class now inherits from GraphQLError rather than directly from error to utilize its methods of properly allow extending the base Error class.

Hopefully fixes: #1367.