### PR TITLE
fix(types): use Records when appropriate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ install:
 
 script:
   - if [[ $GRAPHQL_VERSION == "latest" ]]; then
+      npm run check;
+    fi
+  - if [[ $GRAPHQL_VERSION == "latest" ]]; then
       npm run lint;
     fi
   - if [[ $GRAPHQL_VERSION == "latest" ]]; then

--- a/docs/source/schema-delegation.md
+++ b/docs/source/schema-delegation.md
@@ -118,8 +118,8 @@ delegateToSchema(options: {
   schema: GraphQLSchema;
   operation: 'query' | 'mutation' | 'subscription';
   fieldName: string;
-  args?: { [key: string]: any };
-  context: { [key: string]: any };
+  args?: Record<string, any>;
+  context: Record<string, any>;
   info: GraphQLResolveInfo;
   transforms?: Array<Transform>;
 }): Promise<any>
@@ -137,7 +137,7 @@ The operation type to use during the delegation.
 
 A root field in a subschema from which the query should start.
 
-#### args: { [key: string]: any }
+#### args: Record<string, any>
 
 Additional arguments to be passed to the field. Arguments passed to the field that is being resolved will be preserved if the subschema expects them, so you don't have to pass existing arguments explicitly, though you could use the additional arguments to override the existing ones. For example:
 
@@ -187,7 +187,7 @@ const resolvers = {
 };
 ```
 
-#### context: { [key: string]: any }
+#### context: Record<string, any>
 
 GraphQL context that is going to be passed to the subschema execution or subsciption call.
 

--- a/docs/source/schema-stitching.md
+++ b/docs/source/schema-stitching.md
@@ -382,15 +382,11 @@ The `delegateToSchema` method:
 ```js
 delegateToSchema<TContext>(options: IDelegateToSchemaOptions<TContext>): any;
 
-interface IDelegateToSchemaOptions<TContext = {
-    [key: string]: any;
-}> {
+interface IDelegateToSchemaOptions<TContext = Record<string, any>> {
     schema: GraphQLSchema;
     operation: Operation;
     fieldName: string;
-    args?: {
-        [key: string]: any;
-    };
+    args?: Record<string, any>;
     context: TContext;
     info: GraphQLResolveInfo;
     transforms?: Array<Transform>;

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "precompile": "npm run clean",
     "compile": "rollup -c rollup.config.js",
     "test": "jest",
+    "check": "tsc --noemit",
+    "check:watch": "tsc --watch --noemit",
     "lint": "eslint --ext .js,.ts src",
     "lint:watch": "esw --watch --cache --ext .js,.ts src",
     "watch": "npm run compile -- --watch",

--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -37,22 +37,13 @@ import { ApolloLink } from 'apollo-link';
 import { SchemaVisitor } from './utils/SchemaVisitor';
 import { SchemaDirectiveVisitor } from './utils/SchemaDirectiveVisitor';
 
-export interface SchemaDirectiveVisitorClass {
-  new (...args: any): SchemaDirectiveVisitor;
-  getDirectiveDeclaration(
-    directiveName: string,
-    schema: GraphQLSchema,
-  ): GraphQLDirective | null | undefined;
-}
+export type SchemaDirectiveVisitorClass = typeof SchemaDirectiveVisitor;
 
 // graphql-js < v15 backwards compatible ExecutionResult
 // See: https://github.com/graphql/graphql-js/pull/2490
 
-export interface ExecutionResult<
-  TData = {
-    [key: string]: any;
-  }
-> extends GraphQLExecutionResult {
+export interface ExecutionResult<TData = Record<string, any>>
+  extends GraphQLExecutionResult {
   data?: TData | null;
   extensions?: Record<string, any>;
 }
@@ -66,11 +57,11 @@ export type TypeMap = Record<string, GraphQLNamedType>;
 
 export interface GraphQLExecutionContext {
   schema: GraphQLSchema;
-  fragments: { [key: string]: FragmentDefinitionNode };
+  fragments: Record<string, FragmentDefinitionNode>;
   rootValue: any;
   contextValue: any;
   operation: OperationDefinitionNode;
-  variableValues: { [key: string]: any };
+  variableValues: Record<string, any>;
   fieldResolver: GraphQLFieldResolver<any, any>;
   errors: Array<GraphQLError>;
 }
@@ -183,8 +174,8 @@ export type Fetcher = (
 export interface IFetcherOperation {
   query: DocumentNode;
   operationName?: string;
-  variables?: { [key: string]: any };
-  context?: { [key: string]: any };
+  variables?: Record<string, any>;
+  context?: Record<string, any>;
 }
 
 export type Dispatcher = (context: any) => ApolloLink | Fetcher;
@@ -232,12 +223,12 @@ export function isSubschemaConfig(
   return Boolean((value as SubschemaConfig).schema);
 }
 
-export interface IDelegateToSchemaOptions<TContext = { [key: string]: any }> {
+export interface IDelegateToSchemaOptions<TContext = Record<string, any>> {
   schema: GraphQLSchema | SubschemaConfig;
   operation?: Operation;
   fieldName?: string;
   returnType?: GraphQLOutputType;
-  args?: { [key: string]: any };
+  args?: Record<string, any>;
   selectionSet?: SelectionSetNode;
   fieldNodes?: ReadonlyArray<FieldNode>;
   context?: TContext;
@@ -277,8 +268,8 @@ export interface MergeInfo {
   delegate: (
     type: 'query' | 'mutation' | 'subscription',
     fieldName: string,
-    args: { [key: string]: any },
-    context: { [key: string]: any },
+    args: Record<string, any>,
+    context: Record<string, any>,
     info: GraphQLResolveInfo,
     transforms?: Array<Transform>,
   ) => any;
@@ -328,18 +319,16 @@ export interface IResolverObject<TSource = any, TContext = any, TArgs = any> {
     | IResolverObject<TSource, TContext>;
 }
 
-export interface IEnumResolver {
-  [key: string]: string | number;
-}
+export type IEnumResolver = Record<string, string | number>;
 
-export interface IResolvers<TSource = any, TContext = any> {
-  [key: string]:
-    | (() => any)
-    | IResolverObject<TSource, TContext>
-    | IResolverOptions<TSource, TContext>
-    | GraphQLScalarType
-    | IEnumResolver;
-}
+export type IResolvers<TSource = any, TContext = any> = Record<
+  string,
+  | (() => any)
+  | IResolverObject<TSource, TContext>
+  | IResolverOptions<TSource, TContext>
+  | GraphQLScalarType
+  | IEnumResolver
+>;
 
 export type IResolversParameter =
   | Array<IResolvers | ((mergeInfo: MergeInfo) => IResolvers)>
@@ -358,9 +347,7 @@ export type IConnector<TContext = any> =
   | IConnectorCls<TContext>
   | IConnectorFn<TContext>;
 
-export interface IConnectors<TContext = any> {
-  [key: string]: IConnector<TContext>;
-}
+export type IConnectors<TContext = any> = Record<string, IConnector<TContext>>;
 
 export interface IExecutableSchemaDefinition<TContext = any> {
   typeDefs: ITypeDefinitions;
@@ -422,7 +409,7 @@ export interface IMockOptions {
 export interface IMockServer {
   query: (
     query: string,
-    vars?: { [key: string]: any },
+    vars?: Record<string, any>,
   ) => Promise<ExecutionResult>;
 }
 
@@ -447,7 +434,7 @@ export interface Request {
   extensions?: Record<string, any>;
 }
 
-export type IndexedObject<V> = { [key: string]: V } | ReadonlyArray<V>;
+export type IndexedObject<V> = Record<string, V> | ReadonlyArray<V>;
 
 export type VisitableSchemaType =
   | GraphQLSchema

--- a/src/esUtils/toObjMap.ts
+++ b/src/esUtils/toObjMap.ts
@@ -1,4 +1,6 @@
-export default function toObjMap(obj: any): Record<string, any> {
+export default function toObjMap<T>(obj: {
+  [key: string]: T;
+}): Record<string, T> {
   if (Object.getPrototypeOf(obj) === null) {
     return obj;
   }

--- a/src/mock/index.ts
+++ b/src/mock/index.ts
@@ -105,7 +105,7 @@ function addMocksToSchema({
     // 3. if there's no mock defined, use the default mocks for this type
     return (
       root: any,
-      args: { [key: string]: any },
+      args: Record<string, any>,
       context: any,
       info: GraphQLResolveInfo,
     ): any => {
@@ -227,7 +227,7 @@ function addMocksToSchema({
           ) {
             mockResolver = (
               root: any,
-              args: { [key: string]: any },
+              args: Record<string, any>,
               context: any,
               info: GraphQLResolveInfo,
             ) => {
@@ -256,7 +256,7 @@ function addMocksToSchema({
         const oldResolver = field.resolve;
         field.resolve = (
           rootObject: any,
-          args: { [key: string]: any },
+          args: Record<string, any>,
           context: any,
           info: GraphQLResolveInfo,
         ) =>
@@ -400,7 +400,7 @@ class MockList {
 
   public mock(
     root: any,
-    args: { [key: string]: any },
+    args: Record<string, any>,
     context: any,
     info: GraphQLResolveInfo,
     fieldType: GraphQLList<any>,

--- a/src/stitch/introspectSchema.ts
+++ b/src/stitch/introspectSchema.ts
@@ -16,7 +16,7 @@ const parsedIntrospectionQuery: DocumentNode = parse(getIntrospectionQuery());
 
 export default function introspectSchema(
   linkOrFetcher: ApolloLink | Fetcher,
-  linkContext?: { [key: string]: any },
+  linkContext?: Record<string, any>,
 ): Promise<GraphQLSchema> {
   const fetcher =
     typeof linkOrFetcher === 'function'

--- a/src/stitch/mergeInfo.ts
+++ b/src/stitch/mergeInfo.ts
@@ -56,8 +56,8 @@ export function createMergeInfo(
     delegate(
       operation: 'query' | 'mutation' | 'subscription',
       fieldName: string,
-      args: { [key: string]: any },
-      context: { [key: string]: any },
+      args: Record<string, any>,
+      context: Record<string, any>,
       info: IGraphQLToolsResolveInfo,
       transforms: Array<Transform> = [],
     ) {

--- a/src/test/delegateToSchema.test.ts
+++ b/src/test/delegateToSchema.test.ts
@@ -14,7 +14,7 @@ import {
 } from './fixtures/schemas';
 
 function findPropertyByLocationName(
-  properties: { [key: string]: Property },
+  properties: Record<string, Property>,
   name: string,
 ): Property | undefined {
   for (const key of Object.keys(properties)) {

--- a/src/test/directives.test.ts
+++ b/src/test/directives.test.ts
@@ -170,7 +170,7 @@ describe('@directives', () => {
     function checkDirectives(
       type: VisitableSchemaType,
       typeDirectiveNames: Array<string>,
-      fieldDirectiveMap: { [key: string]: Array<string> } = {},
+      fieldDirectiveMap: Record<string, Array<string>> = {},
     ) {
       expect(getDirectiveNames(type)).toEqual(typeDirectiveNames);
 

--- a/src/test/fixtures/schemas.ts
+++ b/src/test/fixtures/schemas.ts
@@ -78,11 +78,11 @@ export type Vehicle = {
 };
 
 export const sampleData: {
-  Property: { [key: string]: Property };
-  Product: { [key: string]: Product };
-  Booking: { [key: string]: Booking };
-  Customer: { [key: string]: Customer };
-  Vehicle: { [key: string]: Vehicle };
+  Property: Record<string, Property>;
+  Product: Record<string, Product>;
+  Booking: Record<string, Booking>;
+  Customer: Record<string, Customer>;
+  Vehicle: Record<string, Vehicle>;
 } = {
   Product: {
     pd1: {

--- a/src/test/mocking.test.ts
+++ b/src/test/mocking.test.ts
@@ -736,9 +736,9 @@ describe('Mock', () => {
     const jsSchema = buildSchemaFromTypeDefinitions(shorthand);
     const mockMap = {
       RootQuery: () => ({
-        returnInt: (_root: any, _args: { [key: string]: any }) => 42, // a) in resolvers, will not be used
-        returnFloat: (_root: any, _args: { [key: string]: any }) => 1.3, // b) not in resolvers, will be used
-        returnString: (_root: any, _args: { [key: string]: any }) =>
+        returnInt: (_root: any, _args: Record<string, any>) => 42, // a) in resolvers, will not be used
+        returnFloat: (_root: any, _args: Record<string, any>) => 1.3, // b) not in resolvers, will be used
+        returnString: (_root: any, _args: Record<string, any>) =>
           Promise.resolve('foo'), // c) in resolvers, will not be used
       }),
     };
@@ -1096,7 +1096,7 @@ describe('Mock', () => {
     const jsSchema = buildSchemaFromTypeDefinitions(shorthand);
     const mockMap = {
       RootQuery: () => ({
-        returnStringArgument: (_o: any, a: { [key: string]: any }) => a['s'],
+        returnStringArgument: (_o: any, a: Record<string, any>) => a['s'],
       }),
     };
     addMocksToSchema({ schema: jsSchema, mocks: mockMap });
@@ -1115,7 +1115,7 @@ describe('Mock', () => {
     const jsSchema = buildSchemaFromTypeDefinitions(shorthand);
     const mockMap = {
       RootMutation: () => ({
-        returnStringArgument: (_o: any, a: { [key: string]: any }) => a['s'],
+        returnStringArgument: (_o: any, a: Record<string, any>) => a['s'],
       }),
     };
     addMocksToSchema({ schema: jsSchema, mocks: mockMap });
@@ -1169,7 +1169,7 @@ describe('Mock', () => {
     const jsSchema = buildSchemaFromTypeDefinitions(shorthand);
     const mockMap = {
       RootQuery: () => ({
-        returnListOfIntArg: (_o: any, a: { [key: string]: any }) =>
+        returnListOfIntArg: (_o: any, a: Record<string, any>) =>
           new MockList(a['l']),
       }),
       Int: () => 12,
@@ -1244,7 +1244,7 @@ describe('Mock', () => {
         returnListOfListOfIntArg: () =>
           new MockList(
             2,
-            (_o: any, a: { [key: string]: any }) => new MockList(a['l']),
+            (_o: any, a: Record<string, any>) => new MockList(a['l']),
           ),
       }),
       Int: () => 12,
@@ -1298,16 +1298,16 @@ describe('Mock', () => {
     // unintuitive corner-cases
     const mockMap = {
       RootQuery: () => ({
-        thread: (_o: any, a: { [key: string]: any }) => ({ id: a['id'] }),
-        threads: (_o: any, a: { [key: string]: any }) =>
+        thread: (_o: any, a: Record<string, any>) => ({ id: a['id'] }),
+        threads: (_o: any, a: Record<string, any>) =>
           new MockList(ITEMS_PER_PAGE * a['num']),
       }),
       Thread: () => ({
         name: 'Lorem Ipsum',
-        posts: (_o: any, a: { [key: string]: any }) =>
+        posts: (_o: any, a: Record<string, any>) =>
           new MockList(
             ITEMS_PER_PAGE * a['num'],
-            (_oi: any, ai: { [key: string]: any }) => ({
+            (_oi: any, ai: Record<string, any>) => ({
               id: ai['num'],
             }),
           ),

--- a/src/test/schemaGenerator.test.ts
+++ b/src/test/schemaGenerator.test.ts
@@ -88,11 +88,10 @@ const testSchema = `
 const testResolvers = {
   __schema: () => ({ stuff: 'stuff', species: 'ROOT' }),
   RootQuery: {
-    usecontext: (_r: any, _a: { [key: string]: any }, ctx: any) =>
-      ctx.usecontext,
-    useTestConnector: (_r: any, _a: { [key: string]: any }, ctx: any) =>
+    usecontext: (_r: any, _a: Record<string, any>, ctx: any) => ctx.usecontext,
+    useTestConnector: (_r: any, _a: Record<string, any>, ctx: any) =>
       ctx.connectors.TestConnector.get(),
-    useContextConnector: (_r: any, _a: { [key: string]: any }, ctx: any) =>
+    useContextConnector: (_r: any, _a: Record<string, any>, ctx: any) =>
       ctx.connectors.ContextConnector.get(),
     species: (root: any, { name }: { name: string }) =>
       (root.species as string) + name,
@@ -1984,7 +1983,7 @@ describe('providing useful errors from resolvers', () => {
     `;
     const resolve = {
       RootQuery: {
-        thread(_root: any, args: { [key: string]: any }) {
+        thread(_root: any, args: Record<string, any>) {
           return args;
         },
       },
@@ -2024,7 +2023,7 @@ describe('providing useful errors from resolvers', () => {
       `;
     const resolve = {
       RootQuery: {
-        thread(_root: any, _args: { [key: string]: any }) {
+        thread(_root: any, _args: Record<string, any>) {
           return { name: (): any => undefined };
         },
       },
@@ -2061,7 +2060,7 @@ describe('providing useful errors from resolvers', () => {
     `;
     const resolve = {
       RootQuery: {
-        thread(_root: any, args: { [key: string]: any }) {
+        thread(_root: any, args: Record<string, any>) {
           return { name: () => args['name'] };
         },
       },
@@ -2170,15 +2169,12 @@ describe('Attaching connectors to schema', () => {
     test('runs only once per query', () => {
       const simpleResolvers = {
         RootQuery: {
-          usecontext: (_r: any, _a: { [key: string]: any }, ctx: any) =>
+          usecontext: (_r: any, _a: Record<string, any>, ctx: any) =>
             ctx.usecontext,
-          useTestConnector: (_r: any, _a: { [key: string]: any }, ctx: any) =>
+          useTestConnector: (_r: any, _a: Record<string, any>, ctx: any) =>
             ctx.connectors.TestConnector.get(),
-          useContextConnector: (
-            _r: any,
-            _a: { [key: string]: any },
-            ctx: any,
-          ) => ctx.connectors.ContextConnector.get(),
+          useContextConnector: (_r: any, _a: Record<string, any>, ctx: any) =>
+            ctx.connectors.ContextConnector.get(),
           species: (root: any, { name }: { name: string }) =>
             (root.species as string) + name,
         },
@@ -2212,15 +2208,12 @@ describe('Attaching connectors to schema', () => {
     test('runs twice for two queries', () => {
       const simpleResolvers = {
         RootQuery: {
-          usecontext: (_r: any, _a: { [key: string]: any }, ctx: any) =>
+          usecontext: (_r: any, _a: Record<string, any>, ctx: any) =>
             ctx.usecontext,
-          useTestConnector: (_r: any, _a: { [key: string]: any }, ctx: any) =>
+          useTestConnector: (_r: any, _a: Record<string, any>, ctx: any) =>
             ctx.connectors.TestConnector.get(),
-          useContextConnector: (
-            _r: any,
-            _a: { [key: string]: any },
-            ctx: any,
-          ) => ctx.connectors.ContextConnector.get(),
+          useContextConnector: (_r: any, _a: Record<string, any>, ctx: any) =>
+            ctx.connectors.ContextConnector.get(),
           species: (root: any, { name }: { name: string }) =>
             (root.species as string) + name,
         },
@@ -2267,7 +2260,7 @@ describe('Attaching connectors to schema', () => {
         typeDefs: testSchema,
         resolvers: testResolvers,
       });
-      const rootResolver = (_o: any, _a: { [key: string]: any }, ctx: any) => {
+      const rootResolver = (_o: any, _a: Record<string, any>, ctx: any) => {
         ctx['usecontext'] = 'ABC';
       };
       addSchemaLevelResolver(jsSchema, rootResolver);
@@ -2285,7 +2278,7 @@ describe('Attaching connectors to schema', () => {
     test('can attach with existing static connectors', () => {
       const resolvers = {
         RootQuery: {
-          testString(_root: any, _args: { [key: string]: any }, ctx: any) {
+          testString(_root: any, _args: Record<string, any>, ctx: any) {
             return ctx.connectors.staticString;
           },
         },

--- a/src/utils/SchemaDirectiveVisitor.ts
+++ b/src/utils/SchemaDirectiveVisitor.ts
@@ -62,8 +62,8 @@ import { getArgumentValues } from './getArgumentValues';
 // of the SchemaDirectiveVisitor class.
 
 export class SchemaDirectiveVisitor<
-  TArgs = Record<string, any>,
-  TContext = Record<string, any>
+  TArgs = any,
+  TContext = any
 > extends SchemaVisitor {
   // The name of the directive this visitor is allowed to visit (that is, the
   // identifier that appears after the @ character in the schema). Note that
@@ -114,9 +114,7 @@ export class SchemaDirectiveVisitor<
     directiveVisitors: Record<string, SchemaDirectiveVisitorClass>,
     // Optional context object that will be available to all visitor instances
     // via this.context. Defaults to an empty null-prototype object.
-    context: {
-      [key: string]: any;
-    } = Object.create(null),
+    context: Record<string, any> = Object.create(null),
     // The visitSchemaDirectives method returns a map from directive names to
     // lists of SchemaDirectiveVisitors created while visiting the schema.
   ): Record<string, Array<SchemaDirectiveVisitor>> {
@@ -170,7 +168,7 @@ export class SchemaDirectiveVisitor<
         }
 
         const decl = declaredDirectives[directiveName];
-        let args: { [key: string]: any };
+        let args: Record<string, any>;
 
         if (decl != null) {
           // If this directive was explicitly declared, use the declared

--- a/src/utils/SchemaVisitor.ts
+++ b/src/utils/SchemaVisitor.ts
@@ -24,7 +24,7 @@ export abstract class SchemaVisitor {
 
   // Determine if this SchemaVisitor (sub)class implements a particular
   // visitor method.
-  public static implementsVisitorMethod(methodName: string) {
+  public static implementsVisitorMethod(methodName: string): boolean {
     if (!methodName.startsWith('visit')) {
       return false;
     }

--- a/src/utils/fragments.ts
+++ b/src/utils/fragments.ts
@@ -39,65 +39,62 @@ export function concatInlineFragments(
 function deduplicateSelection(
   nodes: Array<SelectionNode>,
 ): Array<SelectionNode> {
-  const selectionMap = nodes.reduce<{ [key: string]: SelectionNode }>(
-    (map, node) => {
-      switch (node.kind) {
-        case 'Field': {
-          if (node.alias != null) {
-            if (node.alias.value in map) {
-              return map;
-            }
-
-            return {
-              ...map,
-              [node.alias.value]: node,
-            };
-          }
-
-          if (node.name.value in map) {
+  const selectionMap = nodes.reduce((map, node) => {
+    switch (node.kind) {
+      case 'Field': {
+        if (node.alias != null) {
+          if (node.alias.value in map) {
             return map;
           }
 
           return {
             ...map,
-            [node.name.value]: node,
+            [node.alias.value]: node,
           };
         }
-        case 'FragmentSpread': {
-          if (node.name.value in map) {
-            return map;
-          }
 
-          return {
-            ...map,
-            [node.name.value]: node,
-          };
-        }
-        case 'InlineFragment': {
-          if (map.__fragment != null) {
-            const fragment = map.__fragment as InlineFragmentNode;
-
-            return {
-              ...map,
-              __fragment: concatInlineFragments(
-                fragment.typeCondition.name.value,
-                [fragment, node],
-              ),
-            };
-          }
-
-          return {
-            ...map,
-            __fragment: node,
-          };
-        }
-        default: {
+        if (node.name.value in map) {
           return map;
         }
+
+        return {
+          ...map,
+          [node.name.value]: node,
+        };
       }
-    },
-    Object.create(null),
-  );
+      case 'FragmentSpread': {
+        if (node.name.value in map) {
+          return map;
+        }
+
+        return {
+          ...map,
+          [node.name.value]: node,
+        };
+      }
+      case 'InlineFragment': {
+        if (map.__fragment != null) {
+          const fragment = map.__fragment as InlineFragmentNode;
+
+          return {
+            ...map,
+            __fragment: concatInlineFragments(
+              fragment.typeCondition.name.value,
+              [fragment, node],
+            ),
+          };
+        }
+
+        return {
+          ...map,
+          __fragment: node,
+        };
+      }
+      default: {
+        return map;
+      }
+    }
+  }, Object.create(null));
 
   const selection = Object.keys(selectionMap).reduce(
     (selectionList, node) => selectionList.concat(selectionMap[node]),

--- a/src/wrap/transforms/AddArgumentsAsVariables.ts
+++ b/src/wrap/transforms/AddArgumentsAsVariables.ts
@@ -44,10 +44,10 @@ export default class AddArgumentsAsVariables implements Transform {
 function addVariablesToRootField(
   targetSchema: GraphQLSchema,
   originalRequest: Request,
-  args: { [key: string]: any },
+  args: Record<string, any>,
 ): {
   document: DocumentNode;
-  newVariables: { [key: string]: any };
+  newVariables: Record<string, any>;
 } {
   const document = originalRequest.document;
   const variableValues = originalRequest.variables;

--- a/src/wrap/transforms/RenameRootTypes.ts
+++ b/src/wrap/transforms/RenameRootTypes.ts
@@ -17,8 +17,8 @@ import { toConfig } from '../../polyfills/index';
 
 export default class RenameRootTypes implements Transform {
   private readonly renamer: (name: string) => string | undefined;
-  private map: { [key: string]: string };
-  private reverseMap: { [key: string]: string };
+  private map: Record<string, string>;
+  private reverseMap: Record<string, string>;
 
   constructor(renamer: (name: string) => string | undefined) {
     this.renamer = renamer;


### PR DESCRIPTION
= Use Record instead of { [key: string]: <whatever> } when possible.
= Use any for SchemaDirectiveVisitor generic default, a simpler attempt at #1376
= Add typescript check, as rollup seems to fail only on semantic/syntax errors, not type errors